### PR TITLE
thenReturn<Answer>InOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,28 @@ when(repo.futureVoidFunction).thenAnswerWithVoid();
 ```  
 
 #### thenAnswerWith(T)
-
 ```dart  
 // Instead of doing:  
 when(repo.futureIntFunction).thenAnswer((invocation) async => 10);  
 // You can just:  
 when(repo.futureIntFunction).thenAnswerWith(10);  
+```  
+
+#### thenAnswerInOrder(List<Answer<T>>)
+```dart  
+// Instead of doing:  
+final List<Future<int> Function(Invocation)> answers = [
+(_) async => 6,
+(_) async => 7,
+(_) async => 99,
+]; 
+when(() => repo.asyncInteger()).thenAnswer((invocation) => answers.removeAt(0)(invocation));
+// You can just:  
+when(() => repo.asyncInteger()).thenAnswerInOrder([
+    (invocation) async => 6,
+    (_) async => 7,
+    (_) async => 99,
+]);
 ```  
 
 
@@ -52,3 +68,22 @@ when(repo.voidFunction).thenReturn(null);
 // You can just:  
 when(repo.voidFunction).thenReturnWithVoid();   
 ```  
+
+#### thenReturnInOrder(List<T>)
+```dart  
+// Instead of doing:  
+when(() => repo.addOne(1)).thenReturn(6);
+when(() => repo.addOne(2)).thenReturn(7);
+when(() => repo.addOne(3)).thenReturn(99);
+
+// You can just:  
+when(() => repo.addOne(any())).thenReturnInOrder([6, 7, 99]);
+```
+```dart  
+// Instead of doing:  
+final answers = [6, 7, 99];
+when(() => repo.addOne(1)).thenAnswer((invocation) => answers.removeAt(0));
+
+// You can just:  
+when(() => repo.addOne(1)).thenReturnInOrder([6, 7, 99]);
+```

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,16 +1,1 @@
-# Defines a default set of lint rules enforced for projects at Google. For
-# details and rationale, see
-# https://github.com/dart-lang/pedantic#enabled-lints.
-
-include: package:pedantic/analysis_options.yaml
-
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
-
-# Uncomment to specify additional rules.
-# linter:
-#   rules:
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
+include: package:lints/recommended.yaml

--- a/lib/src/mocktailx_base.dart
+++ b/lib/src/mocktailx_base.dart
@@ -32,3 +32,29 @@ extension VoidAnswerOnVoid on When<void> {
   /// The function will be called and returned with a null result.
   void thenReturnWithVoid() => thenReturn(null);
 }
+
+extension WhenExtension<T> on When<T> {
+  void thenAnswerInOrder(List<Answer<T>> answers) {
+    final originalCount = answers.length;
+    return thenAnswer((invocation) {
+      if (answers.isEmpty) {
+        throw Exception(
+          '$originalCount callbacks provided but invoked ${originalCount + 1} times. No more answers available.',
+        );
+      }
+      return answers.removeAt(0)(invocation);
+    });
+  }
+
+  void thenReturnInOrder(List<T> answers) {
+    final originalCount = answers.length;
+    return thenAnswer((invocation) {
+      if (answers.isEmpty) {
+        throw Exception(
+          '$originalCount callbacks provided but invoked ${originalCount + 1} times. No more answers available.',
+        );
+      }
+      return answers.removeAt(0);
+    });
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   mocktail: ^1.0.1
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^3.0.0
   test: ^1.17.5

--- a/test/mocktailx_test.dart
+++ b/test/mocktailx_test.dart
@@ -129,13 +129,12 @@ class Person {
   Person(this.name);
 
   @override
-  bool operator ==(Object other) {
-    if (other is Person) {
-      return name == other.name;
-    }
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Person && runtimeType == other.runtimeType && name == other.name;
 
-    return false;
-  }
+  @override
+  int get hashCode => name.hashCode;
 }
 
 class TestRepository {

--- a/test/mocktailx_test.dart
+++ b/test/mocktailx_test.dart
@@ -52,6 +52,75 @@ void main() {
     expect(repo.streamValue(), emitsInOrder([0, 1, 2, 3]));
     verify(repo.streamValue).called(1);
   });
+
+  group('thenReturnInOrder', () {
+    test('returns different outputs called consecutively with the same input',
+        () {
+
+      when(() => repo.addOne(1)).thenReturnInOrder([6, 7, 99]);
+
+      expect(repo.addOne(1), 6);
+      expect(repo.addOne(1), 7);
+      expect(repo.addOne(1), 99);
+    });
+
+    test('returns different outputs called consecutively with any() input', () {
+      when(() => repo.addOne(any())).thenReturnInOrder([6, 7, 99]);
+
+      expect(repo.addOne(1), 6);
+      expect(repo.addOne(2), 7);
+      expect(repo.addOne(3), 99);
+    });
+
+    test('throws if invocations do not match callback count', () {
+      when(() => repo.addOne(any())).thenReturnInOrder([6]);
+
+      expect(repo.addOne(1), 6);
+      try {
+        repo.addOne(2);
+      } on Exception catch (e) {
+        expect(e.toString(),
+            'Exception: 1 callbacks provided but invoked 2 times. No more answers available.');
+        return;
+      }
+      fail('Exception block not executed.');
+    });
+  });
+
+  group('thenAnswerInOrder', () {
+    test('returns different outputs called consecutively with the same input',
+        () async {
+      when(() => repo.asyncInteger()).thenAnswerInOrder([
+        (invocation) async => 6,
+        (_) async => 7,
+        (_) async => 99,
+      ]);
+
+      int result = await repo.asyncInteger();
+      expect(result, 6);
+      result = await repo.asyncInteger();
+      expect(result, 7);
+      result = await repo.asyncInteger();
+      expect(result, 99);
+    });
+
+    test('throws if invocations do not match callback count', () async {
+      when(() => repo.asyncInteger()).thenAnswerInOrder([
+        (invocation) async => 6,
+      ]);
+
+      int result = await repo.asyncInteger();
+      expect(result, 6);
+      try {
+        await repo.asyncInteger();
+      } on Exception catch (e) {
+        expect(e.toString(),
+            'Exception: 1 callbacks provided but invoked 2 times. No more answers available.');
+        return;
+      }
+      fail('Exception block not executed.');
+    });
+  });
 }
 
 class Person {


### PR DESCRIPTION
https://github.com/shinayser/mocktailx/issues/5

- Replaced pedantic (deprecated) with lints
- Added `thenReturnInOrder(List<T> answers)` and `thenAnswerInOrder(List<Answer<T>>)`

 Let me know what you think.